### PR TITLE
fix: support admin auth in edge runtime

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,8 +1,8 @@
-﻿import type { ReactNode } from "react";
+import type { ReactNode } from "react";
 import { assertAdminSessionOrRedirect } from "@/lib/auth";
 
-export default function AdminLayout({ children }: { children: ReactNode }) {
-  assertAdminSessionOrRedirect();
+export default async function AdminLayout({ children }: { children: ReactNode }) {
+  await assertAdminSessionOrRedirect();
 
   return <div className="min-h-screen bg-brand-navy text-brand-ice">{children}</div>;
 }

--- a/app/api/admin/comments/[id]/route.ts
+++ b/app/api/admin/comments/[id]/route.ts
@@ -11,7 +11,7 @@ type RouteContext = {
 
 export async function PATCH(request: Request, context: RouteContext) {
   const token = cookies().get(ADMIN_SESSION_COOKIE)?.value;
-  if (!verifySessionToken(token)) {
+  if (!(await verifySessionToken(token))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/app/api/admin/login/route.ts
+++ b/app/api/admin/login/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Неверный пароль" }, { status: 401 });
   }
 
-  setAdminSession();
+  await setAdminSession();
 
   return NextResponse.json({ success: true });
 }

--- a/app/api/admin/media/upload/route.ts
+++ b/app/api/admin/media/upload/route.ts
@@ -17,16 +17,16 @@ const ALLOWED_TYPES: Record<string, "jpeg" | "png" | "webp"> = {
   "image/webp": "webp",
 };
 
-function ensureAdmin() {
+async function ensureAdmin() {
   const token = cookies().get(ADMIN_SESSION_COOKIE)?.value;
-  if (!verifySessionToken(token)) {
+  if (!(await verifySessionToken(token))) {
     throw new Error("UNAUTHORIZED");
   }
 }
 
 export async function POST(request: Request) {
   try {
-    ensureAdmin();
+    await ensureAdmin();
     assertCsrf(request);
   } catch (error) {
     const status = error instanceof Error && error.message === "UNAUTHORIZED" ? 401 : 403;

--- a/app/api/admin/posts/[id]/route.ts
+++ b/app/api/admin/posts/[id]/route.ts
@@ -12,9 +12,9 @@ type RouteContext = {
   params: { id: string };
 };
 
-function ensureAdmin() {
+async function ensureAdmin() {
   const token = cookies().get(ADMIN_SESSION_COOKIE)?.value;
-  if (!verifySessionToken(token)) {
+  if (!(await verifySessionToken(token))) {
     throw new Error("UNAUTHORIZED");
   }
 }
@@ -32,7 +32,7 @@ function normalizeSlug(input: string) {
 
 export async function GET(request: Request, context: RouteContext) {
   try {
-    ensureAdmin();
+    await ensureAdmin();
   } catch (error) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -56,7 +56,7 @@ export async function GET(request: Request, context: RouteContext) {
 
 export async function PUT(request: Request, context: RouteContext) {
   try {
-    ensureAdmin();
+    await ensureAdmin();
     assertCsrf(request);
   } catch (error) {
     const status = error instanceof Error && error.message === "UNAUTHORIZED" ? 401 : 403;
@@ -133,7 +133,7 @@ export async function PUT(request: Request, context: RouteContext) {
 
 export async function DELETE(request: Request, context: RouteContext) {
   try {
-    ensureAdmin();
+    await ensureAdmin();
     assertCsrf(request);
   } catch (error) {
     const status = error instanceof Error && error.message === "UNAUTHORIZED" ? 401 : 403;

--- a/app/api/admin/posts/route.ts
+++ b/app/api/admin/posts/route.ts
@@ -8,9 +8,9 @@ import { verifySessionToken } from "@/lib/auth";
 import { assertCsrf } from "@/lib/csrf";
 import { sanitizeHtml } from "@/lib/sanitize";
 
-function ensureAdmin() {
+async function ensureAdmin() {
   const token = cookies().get(ADMIN_SESSION_COOKIE)?.value;
-  if (!verifySessionToken(token)) {
+  if (!(await verifySessionToken(token))) {
     throw new Error("UNAUTHORIZED");
   }
 }
@@ -26,7 +26,7 @@ function normalizeSlug(input: string) {
 
 export async function POST(request: Request) {
   try {
-    ensureAdmin();
+    await ensureAdmin();
     assertCsrf(request);
   } catch (error) {
     const status = error instanceof Error && error.message === "UNAUTHORIZED" ? 401 : 403;
@@ -114,7 +114,7 @@ export async function POST(request: Request) {
 
 export async function GET() {
   try {
-    ensureAdmin();
+    await ensureAdmin();
   } catch (error) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,6 +1,5 @@
 ﻿import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import crypto from "node:crypto";
 import { ADMIN_SESSION_COOKIE } from "./constants";
 
 function getAdminSecret(): string {
@@ -11,30 +10,58 @@ function getAdminSecret(): string {
   return secret;
 }
 
-function getSecretHash(): string {
-  const secret = getAdminSecret();
-  return crypto.createHash("sha256").update(secret).digest("hex");
+const encoder = new TextEncoder();
+
+let cachedHash: string | null = null;
+let computingHash: Promise<string> | null = null;
+
+async function getSecretHash(): Promise<string> {
+  if (cachedHash) {
+    return cachedHash;
+  }
+
+  if (!computingHash) {
+    computingHash = (async () => {
+      const secret = getAdminSecret();
+      if (!globalThis.crypto?.subtle) {
+        throw new Error("Web Crypto API is not available to hash ADMIN_SECRET");
+      }
+
+      const data = encoder.encode(secret);
+      const digest = await globalThis.crypto.subtle.digest("SHA-256", data);
+      const hashArray = Array.from(new Uint8Array(digest));
+      cachedHash = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+      return cachedHash;
+    })();
+  }
+
+  try {
+    return await computingHash;
+  } finally {
+    computingHash = null;
+  }
 }
 
-export function createSessionToken(): string {
+export async function createSessionToken(): Promise<string> {
   return getSecretHash();
 }
 
-export function verifySessionToken(token: string | undefined): boolean {
+export async function verifySessionToken(token: string | undefined): Promise<boolean> {
   if (!token) {
     return false;
   }
   try {
-    return token === getSecretHash();
+    const secretHash = await getSecretHash();
+    return token === secretHash;
   } catch (error) {
     console.error("Failed to verify admin session", error);
     return false;
   }
 }
 
-export function setAdminSession(): void {
+export async function setAdminSession(): Promise<void> {
   const cookieStore = cookies();
-  cookieStore.set(ADMIN_SESSION_COOKIE, createSessionToken(), {
+  cookieStore.set(ADMIN_SESSION_COOKIE, await createSessionToken(), {
     httpOnly: true,
     sameSite: "strict",
     secure: process.env.NODE_ENV === "production",
@@ -48,10 +75,10 @@ export function clearAdminSession(): void {
   cookieStore.delete(ADMIN_SESSION_COOKIE);
 }
 
-export function assertAdminSessionOrRedirect(): void {
+export async function assertAdminSessionOrRedirect(): Promise<void> {
   const cookieStore = cookies();
   const token = cookieStore.get(ADMIN_SESSION_COOKIE)?.value;
-  if (!verifySessionToken(token)) {
+  if (!(await verifySessionToken(token))) {
     redirect("/admin/login");
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -71,7 +71,7 @@ export async function middleware(request: NextRequest) {
 
   if (request.nextUrl.pathname.startsWith("/admin") && !request.nextUrl.pathname.startsWith("/admin/login")) {
     const session = request.cookies.get(ADMIN_SESSION_COOKIE)?.value;
-    if (!verifySessionToken(session)) {
+    if (!(await verifySessionToken(session))) {
       const loginUrl = new URL("/admin/login", request.url);
       return NextResponse.redirect(loginUrl);
     }


### PR DESCRIPTION
## Summary
- switch admin session hashing to the Web Crypto API and cache the digest for reuse across requests
- update middleware, admin layout, and API routes to await the async auth helpers

## Testing
- npm run lint
- npm run dev
- npm run test *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68cab6ba3c8883218e154e7d14bc873b